### PR TITLE
Fix recipe update issue due to form name change

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -91,7 +91,7 @@ body
     @recipe.increment_revision!
 
     respond_to do |format|
-      if @recipe.valid_body? && @recipe.update_attributes(params[:recipe_form])
+      if @recipe.valid_body? && @recipe.update_attributes(params[:recipe])
         Event.create(:user_id => @recipe.user.id, :recipe_id => @recipe.id, :action => "updated")
         @recipe.upload_images!
         @recipe.create_recipe_revision!

--- a/spec/controllers/recipes_controller_spec.rb
+++ b/spec/controllers/recipes_controller_spec.rb
@@ -53,4 +53,20 @@ describe RecipesController do
       response.should be_success
     end
   end
+
+  describe "#update" do
+    it "updates recipe and redirects to #show" do
+      user = User.create(:email => "test@example.com", :username => "test", :password => "secret")
+      recipe = Recipe.create(:title => "foo", :body => "blah", :commit_message => "first", :slug => "foo", :revision => 1, :user => user)
+
+      sign_in(user)
+
+      put "update", :user_id => user.username, :id => recipe.slug,
+        :recipe => {:title => "foo", :body => "new blah", :commit_message => "second"}
+
+      recipe.reload
+      recipe.body.should == "new blah"
+      response.should redirect_to([user, recipe])
+    end
+  end
 end


### PR DESCRIPTION
The param name changed in a recent refactor and was missed in the update action causing recipe updates to silently fail. This fixes it.
